### PR TITLE
fix vue-strap/src/modal not found error

### DIFF
--- a/Vue_Full_Project/src/views/components/Modals.vue
+++ b/Vue_Full_Project/src/views/components/Modals.vue
@@ -115,7 +115,7 @@
 </template>
 
 <script>
-import modal from 'vue-strap/src/modal'
+import modal from 'vue-strap/src/Modal'
 
 export default {
   name: 'modals',


### PR DESCRIPTION
fix vue-strap/src/modal not found error

```sh
$ cnpm run dev

> genesis-ui@1.8.1 dev /home/ryuu/workspace/admin-template/Prime_Vue_Full
> node build/dev-server.js



 ERROR  Failed to compile with 1 errors                                                                                                                                 11:40:30 PM

This dependency was not found:

* vue-strap/src/modal in ./~/_babel-loader@6.4.1@babel-loader/lib!./~/_vue-loader@11.3.4@vue-loader/lib/selector.js?type=script&index=0!./src/views/components/Modals.vue

To install it, you can run: npm install --save vue-strap/src/modal
> Listening at http://localhost:8080

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mrholek/prime-bootstrap-4-admin-template-with-angularjs-and-angular-2-support/1)
<!-- Reviewable:end -->
